### PR TITLE
fix(flash): Fix fail linker

### DIFF
--- a/esp_flash_nor/idf_component.yml
+++ b/esp_flash_nor/idf_component.yml
@@ -1,6 +1,6 @@
 version: "0.0.1"
 description: "Component of 3rd party NOR flash drivers"
-url: https://github.com/espressif/esp-flash-drivers/esp_flash_nor
+url: https://github.com/espressif/esp-flash-drivers
 dependencies:
   idf:
     version: ">=5.0"

--- a/esp_flash_nor/idf_component.yml
+++ b/esp_flash_nor/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.0.2"
+version: "0.0.3"
 description: "Component of 3rd party NOR flash drivers"
 url: https://github.com/espressif/esp-flash-drivers
 dependencies:

--- a/esp_flash_nor/linker.lf
+++ b/esp_flash_nor/linker.lf
@@ -1,5 +1,5 @@
-[mapping:custom_flash_driver]
-archive: libcustom_flash_driver.a
+[mapping:espressif__esp_flash_nor]
+archive: libespressif__esp_flash_nor.a
 entries:
     if APP_BUILD_TYPE_PURE_RAM_APP = n:
         spi_flash_chip_eon (noflash)


### PR DESCRIPTION
```
2024-08-29 02:56:27    ERROR [Post Build] >>> linker script generation failed for /builds/espressif/esp-idf/examples/storage/custom_flash_driver/build_esp32c2_default/esp-idf/esp_system/ld/sections.ld.in
2024-08-29 02:56:27    ERROR [Post Build] >>> ERROR: 'libcustom_flash_driver.a:spi_flash_chip_eon None' not found
2024-08-29 02:56:27    ERROR [Post Build] >>> In fragment 'custom_flash_driver' defined in '/builds/espressif/esp-idf/examples/storage/custom_flash_driver/managed_components/espressif__esp_flash_nor/linker.lf'.
2024-08-29 02:56:27    ERROR [Post Build] >>> ninja: build stopped: subcommand failed.
2024-08-29 02:56:27    ERROR [Post Build] >>> ninja failed with exit code 1, output of the command is in the /builds/espressif/esp-idf/examples/storage/custom_flash_driver/build_esp32c2_default/log/idf_py_stderr_output_66680 and /builds/espressif/esp-idf/examples/storage/custom_flash_driver/build_esp32c2_default/log/idf_py_stdout_output_66680
```

So I checked there is no `libcustom_flash_driver.a` the real name is `libespressif__esp_flash_nor.a`